### PR TITLE
Add files via upload

### DIFF
--- a/src/mslinks/ShellLink.java
+++ b/src/mslinks/ShellLink.java
@@ -312,7 +312,7 @@ public class ShellLink {
 	 * Set path of target file of directory. Function accepts local paths and network paths.
 	 * Environment variables are accepted but resolved here and aren't kept in link.
 	 */
-	public ShellLink setTarget(String target) {
+	public ShellLink setTarget(String target, boolean forceMappedDrive, boolean forceDirectory) {
 		target = resolveEnvVariables(target);
 		
 		Path tar = Paths.get(target).toAbsolutePath();
@@ -342,10 +342,10 @@ public class ShellLink {
 				idlist.add(new ItemID().setType(ItemID.TYPE_DIRECTORY).setName(path[i]));
 			
 			LinkInfo inf = createLinkInfo();
-			inf.createVolumeID().setDriveType(VolumeID.DRIVE_FIXED);
+			inf.createVolumeID().setDriveType(forceMappedDrive ? VolumeID.DRIVE_REMOTE : VolumeID.DRIVE_FIXED);
 			inf.setLocalBasePath(target);
 			
-			if (Files.isDirectory(tar))
+			if (forceDirectory || Files.isDirectory(tar))
 				header.getFileAttributesFlags().setDirecory();
 			else 
 				idlist.getLast().setType(ItemID.TYPE_FILE);
@@ -355,9 +355,19 @@ public class ShellLink {
 		return this;
 	}
 	
+	public ShellLink setTarget(String target) {
+		return setTarget(target, false, false);
+	}
+	
 	public static ShellLink createLink(String target) {
 		ShellLink sl = new ShellLink();
 		sl.setTarget( target );
+		return sl;
+	}
+	
+	public static ShellLink createLink(String target, boolean forceMappedDrive, boolean forceDirectory) {
+		ShellLink sl = new ShellLink();
+		sl.setTarget(target, forceMappedDrive, forceDirectory);
 		return sl;
 	}
 	


### PR DESCRIPTION
Allows the caller to tell mslinks that the target is a directory. Useful when running in a context that has different file system access than the user will have. Such as a Tomcat server running as a service, that doesn't have access to the target of the link, so can't determine if the link is to a file or a directory.

I don't know if Windows does anything different if a drive type is set as fixed or remote, but I also added the ability to specify that the drive type is DRIVE_REMOTE.