### PR TITLE
Explicitly build for JDK11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,10 @@ plugins {
 
 version = '1.0.7'
 
+apply plugin: 'java'
+sourceCompatibility = 11.0
+targetCompatibility = 11.0
+
 sourceSets {
     main {
         java {


### PR DESCRIPTION
A proposal for targeting JDK11 compatibility

I was hoping to build for JDK8, but the module system stops that.  I then targeted JDK9, but there were too many modern code features, so JDK11 seemed like the way to go. 

Possibly closes #33 